### PR TITLE
Apply role-based auth and student card improvements

### DIFF
--- a/Tasheel.BLL/Models/RegistrationVM.cs
+++ b/Tasheel.BLL/Models/RegistrationVM.cs
@@ -26,8 +26,6 @@ namespace Tasheel.BLL.Models
         public string ConfirmPassword { get; set; }
         public bool IsAgree { get; set; }
 
-        public string role { get; set; }
-
 
     }
 }

--- a/Tasheel.BLL/Repository/CardRepo.cs
+++ b/Tasheel.BLL/Repository/CardRepo.cs
@@ -42,9 +42,16 @@ namespace Tasheel.BLL.Repository
         public async Task<IEnumerable<Card>> GetAllAsync(Expression<Func<Card, bool>> filter = null)
         {
             if (filter == null)
-                return await db.cards.Include(s => s.academicYear).ToListAsync();
+                return await db.cards
+                    .Include(s => s.academicYear)
+                    .Include(s => s.student)
+                    .ToListAsync();
             else
-                return await db.cards.Include(s => s.academicYear).Where(filter).ToListAsync();
+                return await db.cards
+                    .Include(s => s.academicYear)
+                    .Include(s => s.student)
+                    .Where(filter)
+                    .ToListAsync();
         }
 
         public async Task<IEnumerable<CardVM>> GetAsync()
@@ -62,7 +69,10 @@ namespace Tasheel.BLL.Repository
 
         public async Task<Card> GetByIdAsync(Expression<Func<Card, bool>> filter = null)
         {
-            var data = await db.cards.Where(filter).Include(s => s.academicYear).FirstOrDefaultAsync();
+            var data = await db.cards.Where(filter)
+                .Include(s => s.academicYear)
+                .Include(s => s.student)
+                .FirstOrDefaultAsync();
             return data;
         }
     }

--- a/Tasheel.PL/Controllers/AcademicYearController.cs
+++ b/Tasheel.PL/Controllers/AcademicYearController.cs
@@ -11,6 +11,7 @@ namespace Tasheel.PL.Controllers
 {
     
 
+    [Authorize(Roles = "Admin")]
     public class AcademicYearController : Controller
     {
         private readonly Iacademicyear academicyear;
@@ -23,7 +24,6 @@ namespace Tasheel.PL.Controllers
             this .mapper = mapper;
 
         }
-        [Authorize(Roles = "admin")]
         public async Task<IActionResult> Index()
         {
             var data = await academicyear.GetAllAsync();

--- a/Tasheel.PL/Controllers/AccountController.cs
+++ b/Tasheel.PL/Controllers/AccountController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using Tasheel.BLL.Models;
 using Tasheel.DAL.Extend;
@@ -13,12 +12,10 @@ namespace Tasheel.PL.Controllers
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
-        private readonly RoleManager<IdentityRole> _roleManager;
-        public AccountController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, RoleManager<IdentityRole> roleManager)
+        public AccountController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
         {
             _userManager = userManager;
             _signInManager = signInManager;
-            _roleManager = roleManager;
         }
         //public IActionResult Registration()
         //{
@@ -38,8 +35,6 @@ namespace Tasheel.PL.Controllers
         [Microsoft.AspNetCore.Authorization.AllowAnonymous] // Allow anonymous access to the registration page
         public IActionResult Register()
         {
-            ViewBag.role = new SelectList(_roleManager.Roles.ToList(), "Name", "Name");
-
             return View();
         }
 
@@ -56,8 +51,8 @@ namespace Tasheel.PL.Controllers
 
                 if (result.Succeeded)
                 {
-                    // ✅ Assign a role after user creation
-                    await _userManager.AddToRoleAsync(user, model.role); // Change to your desired role
+                    // Assign default role "Parent" after user creation
+                    await _userManager.AddToRoleAsync(user, "Parent");
 
                     await _signInManager.SignInAsync(user, isPersistent: false);
                     return RedirectToAction("Index", "Home");

--- a/Tasheel.PL/Controllers/CardController.cs
+++ b/Tasheel.PL/Controllers/CardController.cs
@@ -8,22 +8,24 @@ using Tasheel.DAL.Entities;
 
 namespace Tasheel.PL.Controllers
 {
+    [Authorize(Roles = "Admin,Parent")]
     public class CardController : Controller
     {
         private readonly ICard card;
         private readonly Iacademicyear academicyear;
+        private readonly IStudent student;
         //نعطي علم اني بنستخد اوتو مابر
         private readonly IMapper mapper;
 
         //تكوين كائن
-        public CardController(ICard CC, IMapper mapper, Iacademicyear AA)
+        public CardController(ICard CC, IMapper mapper, Iacademicyear AA, IStudent SS)
         {
             this.card = CC;
             this.mapper = mapper;
             this.academicyear = AA;
+            this.student = SS;
         }
 
-        [Authorize(Roles ="admin")]
         public async Task<IActionResult> Index()
         {
 
@@ -70,14 +72,17 @@ namespace Tasheel.PL.Controllers
 
             }
         }
-            [HttpGet]
-        public async Task<IActionResult> Create(int studentId)
+        [HttpGet]
+        public async Task<IActionResult> Create(int? studentId)
         {
             var data = await academicyear.GetAllAsync();
             var result = mapper.Map<IEnumerable<AcademicYearVM>>(data);
 
             ViewBag.academicyearList = new SelectList(result, "Id", "Year");
-            ViewBag.studentid = studentId;
+
+            var students = await student.GetAsync();
+            ViewBag.StudentList = new SelectList(students, "Id", "FullName", studentId);
+
             return View();
         }
         [HttpPost]

--- a/Tasheel.PL/Controllers/NationalityController.cs
+++ b/Tasheel.PL/Controllers/NationalityController.cs
@@ -8,7 +8,7 @@ using Tasheel.DAL.Entities;
 
 namespace Tasheel.PL.Controllers
 {
-    //[Authorize]
+    [Authorize(Roles = "Admin")]
     public class NationalityController : Controller
     {
         private readonly Inationality nationality;
@@ -20,7 +20,6 @@ namespace Tasheel.PL.Controllers
             this.nationality = NA;
             this.mapper = mapper;
         }
-        [Authorize(Roles = "admin")]
         public async Task<IActionResult> Index()
         {
             var data = await nationality.GetAllAsync();

--- a/Tasheel.PL/Controllers/StudentController.cs
+++ b/Tasheel.PL/Controllers/StudentController.cs
@@ -13,7 +13,7 @@ using String = System.String;
 
 namespace Tasheel.PL.Controllers
 {
-    //[Authorize]
+    [Authorize(Roles = "Admin,Parent")]
     public class StudentController : Controller
 
     {

--- a/Tasheel.PL/Views/Account/Register.cshtml
+++ b/Tasheel.PL/Views/Account/Register.cshtml
@@ -60,20 +60,6 @@
                     </div>
                     <div class="input-group">
                         <span class="input-group-addon">
-                            <i class="material-icons">person</i>
-                        </span>
-                        <div class="form-line">
-                            <select class="form-control show-tick" asp-for="role" asp-items="(SelectList) ViewBag.role">
-                                <option>اختر صلاحية</option>
-
-                            </select>
-                           
-                        </div>
-
-
-                    </div>
-                    <div class="input-group">
-                        <span class="input-group-addon">
                             <i class="material-icons">lock</i>
                         </span>
                         <div class="form-line">

--- a/Tasheel.PL/Views/Card/Create.cshtml
+++ b/Tasheel.PL/Views/Card/Create.cshtml
@@ -2,7 +2,6 @@
 @model Tasheel.BLL.Models.CardVM
 @{
     ViewBag.Title = "Create";
-    var studentid = ViewBag.studentid == null ? 0 : ViewBag.studentid;
 }
 
 
@@ -15,9 +14,6 @@
 
 
  <form asp-controller="Card" asp-action="Create">
-
-    @*  <input type="hidden" name="studentid" vlaue="@studentid" /> *@
-     <input type="hidden" asp-for="StudentId" value="@studentid">
        <div class="row clearfix" >
                 <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
                     <div class="card">
@@ -32,7 +28,16 @@
 
                     <div class="row clearfix" >
                                 <h3 dir="rtl">البيانات الاولية:</h3>
-						        <div class="col-md-4">
+                                <div class="col-md-4">
+                                    <label asp-for="StudentId"> الطالب</label>
+                                    <div class="input-group">
+                                        <select class="form-control show-tick" asp-for="StudentId" asp-items="(SelectList)ViewBag.StudentList">
+                                            <option>اختر الطالب</option>
+                                        </select>
+                                        <span asp-validation-for="StudentId" class="text-danger"></span>
+                                    </div>
+                                </div>
+                                                        <div class="col-md-4">
                                     <label asp-for="AcademicYearId"> العام الدراسي</label>
 
 							        <div class="input-group">

--- a/Tasheel.PL/Views/_mainLayout.cshtml
+++ b/Tasheel.PL/Views/_mainLayout.cshtml
@@ -105,6 +105,7 @@
                     </li>
                     
                  
+@if (User.IsInRole("Admin")) {
                     <li class="active">
                         <a asp-controller="Nationality" asp-action="Index">
                             <i class="material-icons">badge</i>
@@ -119,6 +120,14 @@
                         </a>
                     </li>
                     <li class="active">
+                        <a asp-controller="Account" asp-action="Register">
+                            <i class="material-icons">edit_square</i>
+                            <span>اضافة مستخدمين</span>
+                        </a>
+                    </li>
+}
+@if (User.IsInRole("Admin") || User.IsInRole("Parent")) {
+                    <li class="active">
                         <a asp-controller="Student" asp-action="Index">
                             <i class="material-icons">person</i>
                             <span>الطالب</span>
@@ -130,12 +139,7 @@
                             <span>بطاقة الطالب الاجتماعية</span>
                         </a>
                     </li>
-                    <li class="active">
-                        <a asp-controller="Account" asp-action="Register">
-                            <i class="material-icons">edit_square</i>
-                            <span>اضافة مستخدمين</span>
-                        </a>
-                    </li>
+}
                 </ul>
             </div>
 


### PR DESCRIPTION
## Summary
- simplify RegistrationVM and remove role selection UI
- default new users to the `Parent` role
- restrict controllers via role-based authorization
- conditionally display navigation items based on role
- allow selecting student when creating a card and include relation in repo
- clean up redundant authorization attributes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688544ede7c08320806ad9ed93c737d0