### PR TITLE
Fix Card delete action

### DIFF
--- a/Tasheel.PL/Controllers/CardController.cs
+++ b/Tasheel.PL/Controllers/CardController.cs
@@ -56,15 +56,22 @@ namespace Tasheel.PL.Controllers
         public async Task<IActionResult> Delete(CardVM obj)
         {
             try
-
             {
-                var data = mapper.Map<Card>(obj);
+                var data = await card.GetByIdAsync(c =>
+                    c.Id == obj.Id &&
+                    c.StudentId == obj.StudentId &&
+                    c.AcademicYearId == obj.AcademicYearId);
+
+                if (data == null)
+                {
+                    TempData["Message"] = "Record not found";
+                    return View(obj);
+                }
 
                 await card.DeleteAsync(data);
                 return RedirectToAction("Index");
 
             }
-
             catch (Exception ex)
             {
                 TempData["Message"] = ex.Message;

--- a/Tasheel.PL/Views/Card/Delete.cshtml
+++ b/Tasheel.PL/Views/Card/Delete.cshtml
@@ -14,6 +14,9 @@
 
 
 <form asp-controller="Card" asp-action="Delete">
+    <input type="hidden" asp-for="Id" />
+    <input type="hidden" asp-for="StudentId" />
+    <input type="hidden" asp-for="AcademicYearId" />
     <div class="row clearfix">
         <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
             <div class="card">


### PR DESCRIPTION
## Summary
- ensure Card delete page posts ID and related keys
- fetch Card entity from DB when performing delete

## Testing
- `dotnet restore tashel.sln`
- `dotnet build tashel.sln`

------
https://chatgpt.com/codex/tasks/task_e_6885540175b88320a48089e0b0a280c5